### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/search/preprocess.py
+++ b/search/preprocess.py
@@ -56,7 +56,7 @@ def remove_special_chars(text):
     """
     schars = ''.join([a for a in string.punctuation if a not in ".,?"])
 
-    text = re.sub('[%s]' % re.escape(schars), '', text)
+    text = re.sub('[{0!s}]'.format(re.escape(schars)), '', text)
     return text
 
 
@@ -89,7 +89,7 @@ def remove_stopwords(text, swords=None):
 def remove_punctuation(text):
     """Replace punctuation mark with space
     """
-    text = re.sub('[%s]' % re.escape(string.punctuation), '', text)
+    text = re.sub('[{0!s}]'.format(re.escape(string.punctuation)), '', text)
     return text
 
 
@@ -132,7 +132,7 @@ def export(outdir, filename, text):
     """Export text to output filename (with directory)
     """
     fname = get_export_path(outdir, filename)
-    print("Exporting text: %s..." % (fname))
+    print("Exporting text: {0!s}...".format((fname)))
     try:
         extdir = os.path.split(fname)[0]
         if not os.path.exists(extdir):

--- a/search/search_names.py
+++ b/search/search_names.py
@@ -241,7 +241,7 @@ if __name__ == "__main__":
             h = reader.fieldnames[:]
             for i in range(args.max_name):
                 for a in RESULT_FIELDS:
-                    h.append('name%d.%s' % (i + 1, a))
+                    h.append('name{0:d}.{1!s}'.format(i + 1, a))
             h.append('count')
             csvwriter.writerow(h)
 

--- a/search/searchengines.py
+++ b/search/searchengines.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
             c.append(count)
             writer.writerow(c)
         elaspe = time.time() - start_time
-        print("Average rate = %f rows/min" % (i * 60 / elaspe))
+        print("Average rate = {0:f} rows/min".format((i * 60 / elaspe)))
     out.close()
 
     # Test new search
@@ -233,5 +233,5 @@ if __name__ == "__main__":
             c.append(count)
             writer.writerow(c)
         elaspe = time.time() - start_time
-        print("Average rate = %f rows/min" % (i * 60 / elaspe))
+        print("Average rate = {0:f} rows/min".format((i * 60 / elaspe)))
     out.close()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:search-names?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:search-names?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
