### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/search/search_names.py
+++ b/search/search_names.py
@@ -266,7 +266,7 @@ if __name__ == "__main__":
             for i in range(args.max_name):
                 for a in RESULT_FIELDS:
                     if a in args.search_cols:
-                        h.append('name%d.%s' % (i + 1, a))
+                        h.append('name{0:d}.{1!s}'.format(i + 1, a))
             if 'count' in args.search_cols:
                 h.append('count')
             csvwriter.writerow(h)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:search-names?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:search-names?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
